### PR TITLE
Tags/URL with non ASCII characters generate encoding exception

### DIFF
--- a/intro_web_data/delicious_import.py
+++ b/intro_web_data/delicious_import.py
@@ -38,7 +38,6 @@ class delicious_import(object):
             
         writer = csv.writer(open("links.csv", 'wb'))
         for entry in data:
-            print entry
             writer.writerow(entry)
         
 

--- a/intro_web_data/delicious_import.py
+++ b/intro_web_data/delicious_import.py
@@ -34,10 +34,11 @@ class delicious_import(object):
             tags = ",".join([t for t in post.getAttribute('tag').split()])
             timestamp = post.getAttribute('time')
             
-            data.append([url, tags])
+            data.append([url.encode("utf-8"), tags.encode("utf-8")])
             
         writer = csv.writer(open("links.csv", 'wb'))
         for entry in data:
+            print entry
             writer.writerow(entry)
         
 


### PR DESCRIPTION
If you have non-ascii characters in your del.icio.us bookmarks an exception is raised, since Python tries to implicitly convert the unicode to str using ascii as the encoding.

You can test with any word containing accents, such as résumé or fiancée http://en.wikipedia.org/wiki/R%C3%A9sum%C3%A9

I added explicit conversion to utf-8 encoding to fix the issue.
