### PR TITLE
UTF-8 encode NY Times data

### DIFF
--- a/intro_web_data/nytimes_pull.py
+++ b/intro_web_data/nytimes_pull.py
@@ -22,10 +22,7 @@ def main(api_key, category, label):
             
     f = open(label, 'w')
     for line in content:
-        try:
-            f.write('%s\n' % line)
-        except UnicodeEncodeError:
-            pass
+        f.write('%s\n' % line.encode('utf-8'))
             
     f.close()
 


### PR DESCRIPTION
Fix issue where exception is ignored. This issue causes only a few  (5-10) lines that contain no UTF-8 data to be written to the data files.
