### PR TITLE
NYTimes v1 API returns 401, updated to v2 API

### DIFF
--- a/intro_web_data/nytimes_pull.py
+++ b/intro_web_data/nytimes_pull.py
@@ -14,8 +14,8 @@ def main(api_key, category, label):
     
     content = []
     for i in range(0,5):
-        # print "http://api.nytimes.com/svc/search/v1/article?query=classifiers_facet:%s&api-key=%s&offset=%s" % (category, api_key, i)
-        h = urllib.urlopen("http://api.nytimes.com/svc/search/v1/article?query=classifiers_facet:%s&api-key=%s&offset=%s" % (category, api_key, i))
+        # print "http://api.nytimes.com/svc/search/v2/articlesearch.json?fq=news_desk:('%s')&api-key=%s&page=%s" % (category, api_key, i)
+        h = urllib.urlopen("http://api.nytimes.com/svc/search/v2/articlesearch.json?fq=news_desk:(\"%s\")&api-key=%s&page=%s" % (category, api_key, i))
         data = json.loads(h.read())
         for result in data['results']:
             content.append(result['body'])
@@ -27,5 +27,5 @@ def main(api_key, category, label):
     f.close()
 
 if __name__ == '__main__':
-    main("f7b4a1749764aec0364b215c354e3a0f:18:25759498", "[Top/Features/Arts]","arts")
-    main("f7b4a1749764aec0364b215c354e3a0f:18:25759498", "[Top/News/Sports]","sports")  
+    main("f7b4a1749764aec0364b215c354e3a0f:18:25759498", "Arts","arts")
+    main("f7b4a1749764aec0364b215c354e3a0f:18:25759498", "Sports","sports")  


### PR DESCRIPTION
I tried running the script and it wasn't working. Running it in the browser returns a 404 response. I got the script working again w/ the v2 API. Here's the changes I made.
